### PR TITLE
remove host in pending state

### DIFF
--- a/config/test1-id.yaml
+++ b/config/test1-id.yaml
@@ -187,6 +187,7 @@ data:
       connect_timeout: 0.25s
       lb_policy: ROUND_ROBIN
       type: EDS
+      ignore_health_on_host_removal: true
       eds_cluster_config:
         eds_config:
           resource_api_version: V3


### PR DESCRIPTION
if EDS cluster cluster has health_checks - removal of host, stuck in `pending_dynamic_removal` status

solution is add `ignore_health_on_host_removal: true` for host removal on EDS updates

https://github.com/envoyproxy/envoy/issues/11527#issuecomment-641695896