### PR TITLE
update to envoy v1.18.2

### DIFF
--- a/chart/testPods.yaml
+++ b/chart/testPods.yaml
@@ -5,7 +5,6 @@ metadata:
 data:
   envoy.yaml: |-
     admin:
-      access_log_path: "/dev/null"
       address:
         socket_address:
           address: 0.0.0.0
@@ -63,7 +62,7 @@ spec:
           name: test-pod-config
       containers:
       - name: test-001
-        image: envoyproxy/envoy:v1.17.1
+        image: envoyproxy/envoy:v1.18.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -108,7 +107,7 @@ spec:
           name: test-pod-config
       containers:
       - name: test-002
-        image: envoyproxy/envoy:v1.17.1
+        image: envoyproxy/envoy:v1.18.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/config/mock/envoy.yaml
+++ b/config/mock/envoy.yaml
@@ -1,5 +1,4 @@
 admin:
-  access_log_path: "/dev/null"
   address:
     socket_address:
       address: 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       --service-zone $$zone
   local-service-a:
     hostname: local-service-a
-    image: envoyproxy/envoy:v1.17.1
+    image: envoyproxy/envoy:v1.18.2
     volumes:
     - ./config/mock/:/etc/envoy/
     ports:
@@ -81,7 +81,7 @@ services:
     - 18001:18000 # admin
   local-service-b:
     hostname: local-service-a
-    image: envoyproxy/envoy:v1.17.1
+    image: envoyproxy/envoy:v1.18.2
     volumes:
     - ./config/mock/:/etc/envoy/
     ports:

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:v1.17.1
+FROM envoyproxy/envoy:v1.18.2
 
 ADD --chown=envoy:envoy https://github.com/maksim-paskal/go-template/releases/download/v0.0.8/go-template-linux-amd64 /usr/local/bin/go-template
 ADD --chown=envoy:envoy https://github.com/maksim-paskal/jaeger-client-cpp/releases/download/v0.5.0/libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so

--- a/envoy/envoy.defaults/envoy.yaml
+++ b/envoy/envoy.defaults/envoy.yaml
@@ -75,7 +75,6 @@ static_resources:
                 port_value: 18080
 
 admin:
-  access_log_path: "/dev/null"
   address:
     socket_address:
       address: 0.0.0.0

--- a/examples/envoy-fix/config/envoy.yaml
+++ b/examples/envoy-fix/config/envoy.yaml
@@ -2,7 +2,6 @@ dynamic_resources:
   cds_config:
     path: /etc/envoy/cds.json
 admin:
-  access_log_path: "/dev/null"
   address:
     socket_address:
       address: 0.0.0.0

--- a/examples/envoy-fix/issue.md
+++ b/examples/envoy-fix/issue.md
@@ -26,7 +26,6 @@ dynamic_resources:
   cds_config:
     path: /etc/envoy/cds.json
 admin:
-  access_log_path: "/dev/null"
   address:
     socket_address:
       address: 0.0.0.0

--- a/examples/zone-aware/docker-compose.yaml
+++ b/examples/zone-aware/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   envoy:
-    image: envoyproxy/envoy:v1.17.1
+    image: envoyproxy/envoy:v1.18.2
     ports:
     - 8000:8000
     - 8001:8001

--- a/examples/zone-aware/envoy.yaml
+++ b/examples/zone-aware/envoy.yaml
@@ -112,7 +112,6 @@ static_resources:
                 address: envoy-control-plane
                 port_value: 18080
 admin:
-  access_log_path: "/dev/null"
   address:
     socket_address:
       address: 0.0.0.0


### PR DESCRIPTION
- update to  https://www.envoyproxy.io/docs/envoy/v1.18.2/version_history/v1.18.0
- remove deprecated access_log_path