### PR TITLE
use TLS to all requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,12 @@ runRaceDetection:
 	-log.pretty -kubeconfig.path=$(KUBECONFIG) \
 	-ssl.crt=certs/CA.crt \
 	-ssl.key=certs/CA.key
+runCli:
+	go run ./cmd/cli -debug -namespace=1 -pod=2 \
+	-tls.CA=certs/CA.crt \
+	-tls.Crt=certs/envoy.crt \
+	-tls.Key=certs/envoy.key
+
 installDev:
 	helm uninstall envoy-control-plane --namespace envoy-control-plane || true
 	helm upgrade envoy-control-plane \
@@ -76,9 +82,9 @@ upgrade:
 	go get -v -u k8s.io/client-go@v0.20.9
 	go mod tidy
 heap:
-	go tool pprof -http=127.0.0.1:8080 http://localhost:18081/debug/pprof/heap
+	go tool pprof -http=127.0.0.1:8080 https+insecure://localhost:18081/debug/pprof/heap
 allocs:
-	go tool pprof -http=127.0.0.1:8080 http://localhost:18081/debug/pprof/heap
+	go tool pprof -http=127.0.0.1:8080 https+insecure://localhost:18081/debug/pprof/heap
 git-prune-gc:
 	curl -sSL https://get.paskal-dev.com/git-prune-gc | sh
 sslInit:

--- a/chart/envoy-control-plane/templates/control-plane.yaml
+++ b/chart/envoy-control-plane/templates/control-plane.yaml
@@ -66,7 +66,7 @@ spec:
       annotations:
         prometheus.io/path: '/api/metrics'
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '18081'
+        prometheus.io/port: '18082'
       labels:
         app: envoy-control-plane
     spec:
@@ -95,12 +95,14 @@ spec:
             memory: 100Mi
         readinessProbe:
           httpGet:
+            scheme: HTTPS
             path: /api/ready
             port: 18081
           initialDelaySeconds: 3
           periodSeconds: 5
         livenessProbe:
           httpGet:
+            scheme: HTTPS
             path: /api/healthz
             port: 18081
           initialDelaySeconds: 10
@@ -108,6 +110,7 @@ spec:
         ports:
         - containerPort: 18080
         - containerPort: 18081
+        - containerPort: 18082
         volumeMounts:
         - name: certs
           mountPath: /certs
@@ -124,7 +127,7 @@ spec:
   - name: xds
     port: 18080
     protocol: TCP
-  - name: http
+  - name: https
     port: 18081
     protocol: TCP
   selector:

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -237,7 +237,10 @@ func main() {
 
 	controlplane.New(ctx, grpcServer)
 
-	go web.NewServer().Start()
+	webServer := web.NewServer()
+
+	go webServer.Start()
+	go webServer.StartTLS()
 
 	log.Info("grpc.address=", *config.Get().GrpcAddress)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,8 @@ type Type struct {
 	WatchNamespaced         *bool          `yaml:"watchNamespaced"`
 	Namespace               *string        `yaml:"namespace"`
 	GrpcAddress             *string        `yaml:"grpcAddress"`
-	WebAddress              *string        `yaml:"webAddress"`
+	WebHTTPAddress          *string        `yaml:"webHttpAddress"`
+	WebHTTPSAddress         *string        `yaml:"webHttpsAddress"`
 	NodeZoneLabel           *string        `yaml:"nodeZoneLabel"`
 	ConfigDrainPeriod       *string        `yaml:"configDrainPeriod"`
 	EndpointCheckPeriod     *string        `yaml:"endpointCheckPeriod"`
@@ -47,6 +48,8 @@ type Type struct {
 	SSLKey                  *string        `yaml:"sslKey"`
 	SSLRotationPeriod       *time.Duration `yaml:"sslRotationPeriod"`
 	EndpointstoreWaitForPod *bool          `yaml:"waitForPod"`
+	WebAdminUser            *string        `yaml:"webAdminUser"`
+	WebAdminPassword        *string        `yaml:"webAdminPassword"`
 }
 
 var config = Type{
@@ -60,7 +63,8 @@ var config = Type{
 	WatchNamespaced:         flag.Bool("namespaced", true, "watch pod in one namespace"),
 	Namespace:               flag.String("namespace", getEnvDefault("MY_POD_NAMESPACE", "default"), "watch namespace"),
 	GrpcAddress:             flag.String("grpc.address", ":18080", "grpc address"),
-	WebAddress:              flag.String("web.address", ":18081", "web address"),
+	WebHTTPSAddress:         flag.String("web.https.address", ":18081", "https web address"),
+	WebHTTPAddress:          flag.String("web.http.address", ":18082", "http web address"),
 	NodeZoneLabel:           flag.String("node.label.zone", "topology.kubernetes.io/zone", "node label region"),
 	ConfigDrainPeriod:       flag.String("config.drainPeriod", "5s", "drain period"),
 	EndpointCheckPeriod:     flag.String("endpoint.checkPeriod", "60s", "check period"),
@@ -70,6 +74,8 @@ var config = Type{
 	SSLKey:                  flag.String("ssl.key", "", "path to CA key"),
 	SSLRotationPeriod:       flag.Duration("ssl.rotation", sslRotationPeriodDefault, "period of certificate rotation"),
 	EndpointstoreWaitForPod: flag.Bool("endpointstore.waitforpod", true, "wait for pods in namespace"),
+	WebAdminUser:            flag.String("web.adminUser", "admin", "basic auth user for admin endpoints"),
+	WebAdminPassword:        flag.String("web.adminPassword", GetVersion(), "basic auth password for admin endpoints"),
 }
 
 func Load() error {

--- a/pkg/configstore/configStore.go
+++ b/pkg/configstore/configStore.go
@@ -179,7 +179,7 @@ func (cs *ConfigStore) loadEndpoint(pod *v1.Pod) {
 			cs.KubernetesEndpoints.Store(pod.Name, podInfo)
 		}
 	} else {
-		log.Warnf("pod %s not valid", pod.Name)
+		log.Debugf("pod %s not valid", pod.Name)
 	}
 }
 

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -27,7 +27,7 @@ import (
 var (
 	client    = &http.Client{}
 	webServer = web.NewServer()
-	ts        = httptest.NewServer(webServer.GetHandler())
+	ts        = httptest.NewServer(webServer.GetHandler(false))
 	ctx       = context.Background()
 )
 


### PR DESCRIPTION
Main improvements - secure all web requests to `envoy-control-plane`, except metrics endpoint - Prometheus can not scrape metrics from insecure server by defaults

Second improvement - all web requests with prefix `/api/admin` require basic auth - user and passwords can be set with flags `-web.adminUser` and `-web.adminPassword` - default password is application version string

Migrate flag `-web.address` to `web.https.address` and `web.http.address`

Add `/api/admin/certs` endpoint to manual create creation. Usage - this request https://localhost:18081/api/admin/certs?name=test - creates certificate with`test` CommonName