### PR TITLE
update envoy to v1.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ containers:
     /usr/local/bin/envoy \
     --config-path /etc/envoy/envoy.yaml \
     --log-level warn \
-    --bootstrap-version 3 \
     --service-cluster test \
     --service-node test1-id
   resources:

--- a/chart/envoy-control-plane/templates/envoy.yaml
+++ b/chart/envoy-control-plane/templates/envoy.yaml
@@ -57,7 +57,6 @@ spec:
           /usr/local/bin/envoy \
           --config-path /etc/envoy/envoy.yaml \
           --log-level warn \
-          --bootstrap-version 3 \
           --service-cluster test \
           --service-node test1-id \
           --service-zone $zone

--- a/chart/envoy-control-plane/templates/testPods.yaml
+++ b/chart/envoy-control-plane/templates/testPods.yaml
@@ -63,7 +63,7 @@ spec:
           name: test-pod-config
       containers:
       - name: test-001
-        image: envoyproxy/envoy:v1.19.1
+        image: envoyproxy/envoy:v1.20.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -108,7 +108,7 @@ spec:
           name: test-pod-config
       containers:
       - name: test-002
-        image: envoyproxy/envoy:v1.19.1
+        image: envoyproxy/envoy:v1.20.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/config/test1-id.yaml
+++ b/config/test1-id.yaml
@@ -94,7 +94,6 @@ data:
           address: 0.0.0.0
           port_value: 8000
       traffic_direction: INBOUND
-      reuse_port: true
       filter_chains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -192,6 +191,9 @@ data:
                 headers:
                 - name: ":path"
                   exact_match: "/healthz"
+                  # need update of github.com/envoyproxy/go-control-plane
+                  # string_match:
+                  #   exact: "/healthz"
 
             - name: envoy.filters.http.router
     routes:
@@ -236,6 +238,25 @@ data:
                 weight: 50
               - name: local_service2
                 weight: 50
+        # need update of github.com/envoyproxy/go-control-plane
+        # - match:
+        #     prefix: "/test-exact-match"
+        #     headers:
+        #     - name: "create-xhprof-of-request"
+        #       string_match:
+        #         exact: "true"
+        #   route:
+        #     cluster: paket-xhprof
+        # - match:
+        #     path: "/test-regex-match"
+        #     headers:
+        #     - name: "cookie"
+        #       string_match:
+        #         safe_regex:
+        #           google_re2: {}
+        #           regex: ".*?(CanaryUser=true).*?"
+        #   route:
+        #     cluster: local_service1
         - match:
             prefix: "/no-ratelimits"
           route:

--- a/config/test2-id.yaml
+++ b/config/test2-id.yaml
@@ -33,7 +33,6 @@ data:
           address: 0.0.0.0
           port_value: 8001
       traffic_direction: INBOUND
-      reuse_port: true
       filter_chains:
       - transport_socket:
           name: envoy.transport_sockets.tls

--- a/config/test3-id.yaml
+++ b/config/test3-id.yaml
@@ -33,7 +33,6 @@ data:
           address: 0.0.0.0
           port_value: 8001
       traffic_direction: INBOUND
-      reuse_port: true
       filter_chains:
       - transport_socket:
           name: envoy.transport_sockets.tls

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,6 @@ services:
       /usr/local/bin/envoy \
       --config-path /etc/envoy/envoy.yaml \
       --log-level warn \
-      --bootstrap-version 3 \
       --service-cluster test \
       --service-node test1-id \
       --drain-time-s 10 \
@@ -89,7 +88,6 @@ services:
     - JAEGER_AGENT_HOST=jaeger
     command:
     - /usr/local/bin/envoy
-    - --bootstrap-version 3
     - --config-path /etc/envoy/envoy.yaml
     - --service-cluster test
     - --service-node test2-id
@@ -110,7 +108,6 @@ services:
     - JAEGER_AGENT_HOST=jaeger
     command:
     - /usr/local/bin/envoy
-    - --bootstrap-version 3
     - --config-path /etc/envoy/envoy.yaml
     - --service-cluster test
     - --service-node test3-id

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:v1.19.1
+FROM envoyproxy/envoy:v1.20.0
 
 ADD --chown=envoy:envoy https://github.com/maksim-paskal/go-template/releases/download/v0.0.8/go-template-linux-amd64 /usr/local/bin/go-template
 ADD --chown=envoy:envoy https://github.com/maksim-paskal/jaeger-client-cpp/releases/download/v0.5.0/libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so

--- a/examples/zone-aware/docker-compose.yaml
+++ b/examples/zone-aware/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   envoy:
-    image: envoyproxy/envoy:v1.19.1
+    image: envoyproxy/envoy:v1.20.0
     ports:
     - 8000:8000
     - 8001:8001
@@ -14,7 +14,6 @@ services:
     - |
       /usr/local/bin/envoy \
       --config-path /etc/envoy/envoy.yaml \
-      --bootstrap-version 3 \
       --log-level warn \
       --service-cluster test \
       --service-node test1-id \


### PR DESCRIPTION
Update to latest envoy v1.20.0, remove deprecated `--bootstrap-version` argument and `reuse_port` from listener configuration now it is already set to true

https://www.envoyproxy.io/docs/envoy/v1.20.0/version_history/current

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>