### PR TITLE
add envoy redis proxy extensions

### DIFF
--- a/cmd/main/extensions.go
+++ b/cmd/main/extensions.go
@@ -17,15 +17,19 @@ envoy type_config's must be loaded in control plane before use in envoy config.
 
 https://github.com/envoyproxy/go-control-plane/tree/master/envoy/extensions/
 */
+
 import (
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/aggregate/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/redis/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ratelimit/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/health_checkers/redis/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/priority/previous_priorities/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"

--- a/config/test1-id.yaml
+++ b/config/test1-id.yaml
@@ -206,6 +206,22 @@ data:
             "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
             stat_prefix: egress_tcpProxy
             cluster: tcpProxy
+    - name: redis_listener
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 6379 }
+      filter_chains:
+      - filters:
+        - name: envoy.filters.network.redis_proxy
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProxy
+            stat_prefix: egress_redis
+            settings:
+              op_timeout: 5s
+              enable_redirection: true
+              enable_command_stats: true
+            prefix_routes:
+              catch_all_route:
+                cluster: redis_cluster
     routes:
     - name: test
       virtual_hosts:
@@ -424,3 +440,34 @@ data:
                 socket_address:
                   address: 127.0.0.1
                   port_value: 18000
+    - name: redis_cluster
+      connect_timeout: 0.25s
+      lb_policy: CLUSTER_PROVIDED
+      dns_lookup_family: V4_ONLY
+      cluster_type:
+        name: envoy.clusters.redis
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.clusters.redis.v3.RedisClusterConfig
+          cluster_refresh_rate: 5s
+          cluster_refresh_timeout: 3s
+          redirect_refresh_interval: 5s
+          redirect_refresh_threshold: 5
+      health_checks:
+      - timeout: 2s
+        interval: 4s
+        unhealthy_threshold: 6
+        healthy_threshold: 1
+        custom_health_check:
+          name: envoy.health_checkers.redis
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.health_checkers.redis.v3.Redis
+            key: "foo"
+      load_assignment:
+        cluster_name: redis_cluster
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: node001
+                  port_value: 6379

--- a/e2e/extensions_test.go
+++ b/e2e/extensions_test.go
@@ -17,15 +17,19 @@ envoy type_config's must be loaded in control plane before use in envoy config.
 
 https://github.com/envoyproxy/go-control-plane/tree/master/envoy/extensions/
 */
+
 import (
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/aggregate/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/redis/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ratelimit/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/health_checkers/redis/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/priority/previous_priorities/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"


### PR DESCRIPTION
add new extensions to use in envoy
```
github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/redis/v3
github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3
github.com/envoyproxy/go-control-plane/envoy/extensions/health_checkers/redis/v3
```