### PR TITLE
add canary traffic switching

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,32 +2,32 @@ release:
   footer: |
     ## Docker Images
     - `paskalmaksim/envoy-control-plane:latest`
-    - `paskalmaksim/envoy-control-plane:{{ .Tag }}`
+    - `paskalmaksim/envoy-control-plane:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}`
     - `paskalmaksim/envoy-docker-image:latest`
-    - `paskalmaksim/envoy-docker-image:{{ .Tag }}`
+    - `paskalmaksim/envoy-docker-image:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}`
 docker_manifests:
 - name_template: paskalmaksim/envoy-control-plane:latest
   image_templates:
-  - paskalmaksim/envoy-control-plane:{{.Tag}}-amd64
-  - paskalmaksim/envoy-control-plane:{{.Tag}}-arm64
+  - paskalmaksim/envoy-control-plane:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-amd64
+  - paskalmaksim/envoy-control-plane:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-arm64
 - name_template: paskalmaksim/envoy-docker-image:latest
   image_templates:
-  - paskalmaksim/envoy-docker-image:{{.Tag}}-amd64
-  - paskalmaksim/envoy-docker-image:{{.Tag}}-arm64
-- name_template: paskalmaksim/envoy-control-plane:{{.Tag}}
+  - paskalmaksim/envoy-docker-image:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-amd64
+  - paskalmaksim/envoy-docker-image:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-arm64
+- name_template: paskalmaksim/envoy-control-plane:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}
   image_templates:
-  - paskalmaksim/envoy-control-plane:{{.Tag}}-amd64
-  - paskalmaksim/envoy-control-plane:{{.Tag}}-arm64
-- name_template: paskalmaksim/envoy-docker-image:{{.Tag}}
+  - paskalmaksim/envoy-control-plane:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-amd64
+  - paskalmaksim/envoy-control-plane:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-arm64
+- name_template: paskalmaksim/envoy-docker-image:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}
   image_templates:
-  - paskalmaksim/envoy-docker-image:{{.Tag}}-amd64
-  - paskalmaksim/envoy-docker-image:{{.Tag}}-arm64
+  - paskalmaksim/envoy-docker-image:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-amd64
+  - paskalmaksim/envoy-docker-image:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-arm64
 dockers:
 - use: buildx
   goos: linux
   goarch: amd64
   image_templates:
-  - paskalmaksim/envoy-control-plane:{{ .Tag }}-amd64
+  - paskalmaksim/envoy-control-plane:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-amd64
   build_flag_templates:
   - "--build-arg=APPVERSION={{.ShortCommit}}"
   - "--platform=linux/amd64"
@@ -38,7 +38,7 @@ dockers:
   goos: linux
   goarch: arm64
   image_templates:
-  - paskalmaksim/envoy-control-plane:{{ .Tag }}-arm64
+  - paskalmaksim/envoy-control-plane:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-arm64
   build_flag_templates:
   - "--build-arg=APPVERSION={{.ShortCommit}}"
   - "--platform=linux/arm64"
@@ -50,7 +50,7 @@ dockers:
   goos: linux
   goarch: amd64
   image_templates:
-  - paskalmaksim/envoy-docker-image:{{ .Tag }}-amd64
+  - paskalmaksim/envoy-docker-image:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-amd64
   extra_files:
   - envoy/
   build_flag_templates:
@@ -64,7 +64,7 @@ dockers:
   goos: linux
   goarch: arm64
   image_templates:
-  - paskalmaksim/envoy-docker-image:{{ .Tag }}-arm64
+  - paskalmaksim/envoy-docker-image:{{if .IsSnapshot}}{{.Version}}{{else}}{{.Tag}}{{end}}-arm64
   extra_files:
   - envoy/
   build_flag_templates:
@@ -92,7 +92,7 @@ builds:
   flags:
   - -trimpath
   ldflags:
-  - -X github.com/maksim-paskal/envoy-control-plane/pkg/config.gitVersion={{.Version}}-{{.ShortCommit}}-{{.Timestamp}}
+  - -s -w -X github.com/maksim-paskal/envoy-control-plane/pkg/config.gitVersion={{.Version}}-{{.ShortCommit}}-{{.Timestamp}}
   goos:
   - linux
   goarch:
@@ -101,7 +101,7 @@ builds:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: "beta"
 changelog:
   sort: asc
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN apk upgrade \
 
 USER 30001
 
-CMD /app/envoy-control-plane
+ENTRYPOINT [ "/app/envoy-control-plane" ]

--- a/config/test1-id.yaml
+++ b/config/test1-id.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: test1-id
   namespace: default
+  annotations:
+    "envoy-control-plane/routes.cluster.weight.docker_service_a": "80"
+    "envoy-control-plane/routes.cluster.weight.docker_service_b": "20"
   labels:
     app: envoy-control-plane
     version: v1
@@ -128,36 +131,37 @@ data:
             - name: envoy.lua
               typed_config:
                 "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
-                inline_code: |
-                  function stringSplit(inputstr, sep)
-                    if sep == nil then
-                      sep = "%s"
+                default_source_code:
+                  inline_string: |
+                    function stringSplit(inputstr, sep)
+                      if sep == nil then
+                        sep = "%s"
+                      end
+                      local t={}
+                      for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
+                        table.insert(t, str)
+                      end
+                      return t
                     end
-                    local t={}
-                    for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
-                      table.insert(t, str)
-                    end
-                    return t
-                  end
-                  function envoy_on_request(request_handle)
-                    -- cookies to save in metadata
-                    local cookiesArray = {"CID"}
-                    local cookie = request_handle:headers():get("cookie")
-                    local dynamicMetadata = request_handle:streamInfo():dynamicMetadata()
+                    function envoy_on_request(request_handle)
+                      -- cookies to save in metadata
+                      local cookiesArray = {"CID"}
+                      local cookie = request_handle:headers():get("cookie")
+                      local dynamicMetadata = request_handle:streamInfo():dynamicMetadata()
 
-                    if cookie ~= nil then
-                      local splitCookieString = stringSplit(cookie, ";")
-                      for i, cookieItem in ipairs(splitCookieString) do
-                        for y, cookiesItem in ipairs(cookiesArray) do
-                          if string.find(cookieItem, cookiesItem) ~= nil then
-                            local cookieKV = stringSplit(cookieItem, "=")
-                            local cookieName = string.gsub(cookieKV[1], "%s+", "")
-                            dynamicMetadata:set("envoy.filters.http.lua.cookie", cookieName, cookieKV[2])
+                      if cookie ~= nil then
+                        local splitCookieString = stringSplit(cookie, ";")
+                        for i, cookieItem in ipairs(splitCookieString) do
+                          for y, cookiesItem in ipairs(cookiesArray) do
+                            if string.find(cookieItem, cookiesItem) ~= nil then
+                              local cookieKV = stringSplit(cookieItem, "=")
+                              local cookieName = string.gsub(cookieKV[1], "%s+", "")
+                              dynamicMetadata:set("envoy.filters.http.lua.cookie", cookieName, cookieKV[2])
+                            end
                           end
                         end
                       end
                     end
-                  end
 
             # simple cookie extraction with header_to_metadata filter
             - name: envoy.filters.http.header_to_metadata
@@ -192,7 +196,7 @@ data:
                   string_match:
                     exact: "/healthz"
 
-            - name: 
+            - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
     - name: tcpProxy
@@ -256,6 +260,15 @@ data:
               descriptor_key: cf-connecting-ip
         routes:
         - match:
+            prefix: "/docker"
+          route:
+            weighted_clusters:
+              clusters:
+              - name: docker_service_a
+                weight: 50
+              - name: docker_service_b
+                weight: 50
+        - match:
             prefix: "/1"
           route:
             cluster: local_service1
@@ -282,7 +295,6 @@ data:
             - name: "cookie"
               string_match:
                 safe_regex:
-                  google_re2: {}
                   regex: ".*?(CanaryUser=true).*?"
           route:
             cluster: local_service1
@@ -402,6 +414,62 @@ data:
                 socket_address:
                   address: 127.0.0.1
                   port_value: 18000
+    - name: docker_service_a
+      connect_timeout: 0.25s
+      lb_policy: ROUND_ROBIN
+      type: STRICT_DNS
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          common_tls_context:
+            tls_certificate_sds_secret_configs:
+            - name: envoy_control_plane_default
+              sds_config:
+                resource_api_version: V3
+                api_config_source:
+                  api_type: GRPC
+                  transport_api_version: V3
+                  grpc_services:
+                  - envoy_grpc:
+                      cluster_name: xds_cluster
+      load_assignment:
+        cluster_name: docker_service_a
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: local-service-a
+                  port_value: 8001
+    - name: docker_service_b
+      connect_timeout: 0.25s
+      lb_policy: ROUND_ROBIN
+      type: STRICT_DNS
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          common_tls_context:
+            tls_certificate_sds_secret_configs:
+            - name: envoy_control_plane_default
+              sds_config:
+                resource_api_version: V3
+                api_config_source:
+                  api_type: GRPC
+                  transport_api_version: V3
+                  grpc_services:
+                  - envoy_grpc:
+                      cluster_name: xds_cluster
+      load_assignment:
+        cluster_name: docker_service_b
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: local-service-b
+                  port_value: 8001
     - name: tls-cluster-example
       connect_timeout: 1s
       type: STATIC

--- a/config/test2-id.yaml
+++ b/config/test2-id.yaml
@@ -9,9 +9,13 @@ metadata:
 data:
   test2-id: |-
     validation:
-      match_subject_alt_names:
-      - exact: "test1-id"
-      - exact: "test"
+      match_typed_subject_alt_names:
+      - san_type: DNS
+        matcher:
+          exact: "test1-id"
+      - san_type: DNS
+        matcher:
+          exact: "test"
     clusters:
     - name: some_service
       connect_timeout: 0.25s
@@ -100,3 +104,5 @@ data:
                       inline_string: "Hello World2"
             http_filters:
             - name: envoy.filters.http.router
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/config/test3-id.yaml
+++ b/config/test3-id.yaml
@@ -9,9 +9,13 @@ metadata:
 data:
   test3-id: |-
     validation:
-      match_subject_alt_names:
-      - exact: "test1-id"
-      - exact: "test"
+      match_typed_subject_alt_names:
+      - san_type: DNS
+        matcher:
+          exact: "test1-id"
+      - san_type: DNS
+        matcher:
+          exact: "test"
     clusters:
     - name: some_service
       connect_timeout: 0.25s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     #- GODEBUG=http2debug=2
     - MY_POD_NAMESPACE=default
     ports:
-    - 18081:18081
+    - 127.0.0.1:18081:18081
     command:
     - /app/envoy-control-plane
     - -log.level=INFO
@@ -26,7 +26,7 @@ services:
   statsd:
     image: prom/statsd-exporter:v0.18.0
     ports:
-    - 9102:9102
+    - 127.0.0.1:9102:9102
   redis:
     image: redis:alpine
   ratelimit:
@@ -59,8 +59,8 @@ services:
       dockerfile: ./envoy/Dockerfile
       context: .
     ports:
-    - 8000:8000   # inbound
-    - 18000:18000 # admin
+    - 127.0.0.1:8000:8000   # inbound
+    - 127.0.0.1:18000:18000 # admin
     volumes:
     - ./envoy/envoy.defaults/envoy.yaml:/envoy/envoy.yaml:ro
     - ./certs/:/certs:ro
@@ -99,10 +99,10 @@ services:
     - ./envoy/envoy.defaults/envoy.yaml:/envoy/envoy.yaml:ro
     - ./certs/:/certs:ro
     ports:
-    - 8001:8001 # service
-    - 18001:18000 # admin
+    - 127.0.0.1:8001:8001 # service
+    - 127.0.0.1:18001:18000 # admin
   local-service-b:
-    hostname: local-service-a
+    hostname: local-service-b
     build:
       dockerfile: ./envoy/Dockerfile
       context: .
@@ -119,8 +119,8 @@ services:
     - ./envoy/envoy.defaults/envoy.yaml:/envoy/envoy.yaml:ro
     - ./certs/:/certs:ro
     ports:
-    - 8002:8001 # service
-    - 18002:18000 # admin
+    - 127.0.0.1:8002:8001 # service
+    - 127.0.0.1:18002:18000 # admin
   jaeger:
     image: jaegertracing/all-in-one:1.20
     command:
@@ -128,4 +128,4 @@ services:
     environment:
     - COLLECTOR_ZIPKIN_HTTP_PORT=9411
     ports:
-    - "16686:16686"
+    - 127.0.0.1:16686:16686

--- a/examples/canary-endpoints/README.md
+++ b/examples/canary-endpoints/README.md
@@ -1,0 +1,3 @@
+```bash
+curl -H "x-canary: 1" http://localhost:8001/
+```

--- a/examples/canary-endpoints/docker-compose.yaml
+++ b/examples/canary-endpoints/docker-compose.yaml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  envoy:
+    image: paskalmaksim/envoy-docker-image:latest
+    ports:
+    - 127.0.0.1:8000:8000
+    - 127.0.0.1:8001:8001
+    volumes:
+    - ./envoy.yaml:/envoy/envoy.yaml:ro
+    command:
+    - /bin/sh
+    - -c
+    - |
+      /usr/local/bin/envoy \
+      --config-path /envoy/envoy.yaml \
+      --log-level warn \
+      --service-cluster test \
+      --service-node test1-id \
+      --service-zone a
+  nginxdemo:
+    hostname: nginxdemo
+    image: nginxdemos/hello:plain-text
+  nginxdemo-canary:
+    hostname: nginxdemo-canary
+    image: nginxdemos/hello:plain-text
+  prometheus:
+    image: prom/prometheus:v2.44.0
+    ports:
+    - 127.0.0.1:9090:9090
+    volumes:
+    - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro

--- a/examples/canary-endpoints/envoy.yaml
+++ b/examples/canary-endpoints/envoy.yaml
@@ -1,0 +1,94 @@
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8001
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          route_config:
+            name: test
+            virtual_hosts:
+            - name: test
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: meta
+          http_filters:
+          - name: envoy.filters.http.header_to_metadata
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config
+              request_rules:
+              - cookie: CanaryUser
+                on_header_present:
+                  metadata_namespace: envoy.lb
+                  key: stage
+                  type: STRING
+                  regex_value_rewrite:
+                    pattern:
+                      regex: "^true$"
+                    substitution: "canary"
+                remove: false
+              - header: x-canary
+                on_header_present:
+                  metadata_namespace: envoy.lb
+                  key: stage
+                  type: STRING
+                  regex_value_rewrite:
+                    pattern:
+                      regex: "^(1|2|3)$"
+                    substitution: "canary"
+                remove: false
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: meta
+    connect_timeout: 0.25s
+    lb_policy: ROUND_ROBIN
+    type: STRICT_DNS
+    lb_subset_config:
+      fallback_policy: DEFAULT_SUBSET
+      default_subset:
+        canary: false
+      subset_selectors:
+      - keys:
+        - stage
+    load_assignment:
+      cluster_name: nginxdemo
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: nginxdemo
+                port_value: 80
+          metadata:
+            filter_metadata:
+              envoy.lb:
+                stage: main
+                canary: false
+        - endpoint:
+            address:
+              socket_address:
+                address: nginxdemo-canary
+                port_value: 80
+          metadata:
+            filter_metadata:
+              envoy.lb:
+                stage: canary
+                canary: true
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8000

--- a/examples/canary-endpoints/prometheus.yml
+++ b/examples/canary-endpoints/prometheus.yml
@@ -1,0 +1,11 @@
+scrape_configs:
+- job_name: "envoy"
+  scrape_interval: 3s
+  scrape_timeout: 3s
+  metrics_path: /stats/prometheus
+  # metric_relabel_configs:
+  # - source_labels: [__name__]
+  #   regex: '^(envoy_cluster_upstream_rq|envoy_cluster_canary_upstream_rq)$'
+  #   action: keep
+  static_configs:
+  - targets: ["envoy:8000"]

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/envoyproxy/go-control-plane v0.11.1
+	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0
 	github.com/maksim-paskal/logrus-hook-sentry v0.0.9
 	github.com/maksim-paskal/utils-go v0.0.6
@@ -36,7 +37,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,11 +24,14 @@ import (
 )
 
 const (
-	AppName                    = "envoy-control-plane"
-	sslRotationPeriodDefault   = 1 * time.Hour
-	endpointCheckPeriodDefault = 60 * time.Second
-	configDrainPeriodDefault   = 5 * time.Second
-	defaultGracePeriod         = 5 * time.Second
+	AppName                      = "envoy-control-plane"
+	annotationRouteClusterWeight = AppName + "/routes.cluster.weight."
+	AnnotationCanaryEnabled      = AppName + "/canary.enabled"
+	CanarySuffix                 = "-canary"
+	sslRotationPeriodDefault     = 1 * time.Hour
+	endpointCheckPeriodDefault   = 60 * time.Second
+	configDrainPeriodDefault     = 5 * time.Second
+	defaultGracePeriod           = 5 * time.Second
 )
 
 type Type struct {

--- a/pkg/configmapsstore/configMapsStore.go
+++ b/pkg/configmapsstore/configMapsStore.go
@@ -58,6 +58,7 @@ func NewConfigMap(ctx context.Context, cm *v1.ConfigMap) error {
 
 		config.ConfigMapName = cm.Name
 		config.ConfigMapNamespace = cm.Namespace
+		config.ConfigMapAnnotations = cm.Annotations
 
 		if config.UseVersionLabel && len(cm.Labels[config.VersionLabelKey]) > 0 {
 			log.Debug("update Id, using UseVersionLabel")


### PR DESCRIPTION
Main purpouse of this changes is to manage canary traffic, there are 2 options of traffic managment:
### 1 - manage weight of clusters in `weighted_clusters`
```yaml
weighted_clusters:
    clusters:
    - name: docker_service_a
      weight: 100
    - name: docker_service_b
      weight: 0
````
can be manage with configmap annotation to split traffic with some weights
```yaml
annotations:
    "envoy-control-plane/routes.cluster.weight.docker_service_a": "80"
    "envoy-control-plane/routes.cluster.weight.docker_service_b": "20"
```

### 2 - manage traffic in A/B testing way, for example all request with some header is serving with main cluster endpoints that have canary option, all other requests is serving with other endpoints. To manage traffic this way you need to to add in your cluster `lb_subset_config`
```yaml
lb_subset_config:
  fallback_policy: DEFAULT_SUBSET
  default_subset:
    canary: false
  subset_selectors:
  - keys:
    - stage
````
and add `http_filter` that will use header x-canary=1 to route to canary endpoint of your cluster
```yaml
- header: x-canary
  on_header_present:
    metadata_namespace: envoy.lb
    key: stage
    type: STRING
    regex_value_rewrite:
      pattern:
        regex: "^1$"
      substitution: "canary"
```
to add canary endpoints to your envoy - you must add kubernetes service with suffix `-canary` and add to this kubernetes service endpoint an annotation
```yaml
annotations:
  envoy-control-plane/canary.enabled: true
```
this will append to `<service>` endpoints from `<service>-canary`